### PR TITLE
Update adventure-platform-bukkit dependency for 1.18 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
+            <version>4.0.1</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>io.paradaux</groupId>
     <artifactId>AutoBroadcast</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <packaging>jar</packaging>
 
     <name>AutoBroadcast</name>

--- a/src/main/resources/AutoBroadcast_en_US.properties
+++ b/src/main/resources/AutoBroadcast_en_US.properties
@@ -4,7 +4,7 @@ locale.version = 2
 
 system.autobroadcast.startup = \n\
   + ------------------------------------ +\n\
-  |     Running AutoBroadcast v2.0.0     |\n\
+  |     Running AutoBroadcast v2.0.1     |\n\
   |       © Rían Errity (Paradaux)       |\n\
   |         https://paradaux.io          |\n\
   + ------------------------------------ \n+


### PR DESCRIPTION
- Update adventure-platform-bukkit dependency from 4.0.0 to 4.0.1.
- Fixing bug where the hover/click was not working on 1.18.
- Changed the plugin's version from 2.0.0 to 2.0.1.